### PR TITLE
Middlewares to check user id of requests

### DIFF
--- a/src/middlewares/user-id-check.middleware.ts
+++ b/src/middlewares/user-id-check.middleware.ts
@@ -1,0 +1,11 @@
+import { NestMiddleware, BadRequestException} from "@nestjs/common";
+import { NextFunction, Request, Response } from "express";
+
+export class UserIdCheckMiddleware implements NestMiddleware { // usar o 'quick fix' para gerar a estrutura do método 'use' da interface
+    use(req: Request, res: Response, next: NextFunction) {
+        if (isNaN(Number(req.params.id)) || Number(req.params.id) <= 0) {
+            throw new BadRequestException('ID inválido');
+        }
+        next();
+    }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,7 +1,8 @@
-import { Module } from "@nestjs/common";
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from "@nestjs/common";
 import { PrismaModule } from "src/prisma/prisma.module";
 import { UserController } from "./user.controller";
 import { UserSevice } from "./user.service";
+import { UserIdCheckMiddleware } from "src/middlewares/user-id-check.middleware";
 
 @Module({
     imports: [PrismaModule],
@@ -9,4 +10,11 @@ import { UserSevice } from "./user.service";
     providers: [UserSevice],
     exports: []
 })
-export class UserModule {}
+export class UserModule implements NestModule {
+    configure(consumer: MiddlewareConsumer) {
+        consumer.apply(UserIdCheckMiddleware).forRoutes({
+            path: 'users/:id',
+            method: RequestMethod.ALL
+        });
+    }
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -15,13 +15,15 @@ export class UserSevice {
         return this.prisma.user.findMany();
     }
     async readOne(id: number) {
+        await this.exists(id);
+
         return this.prisma.user.findUnique({
             where: {id}
         });
     }
     async overwrite(id: number, {name, email, password, birthAt}:OverwriteUserDTO) {
         await this.exists(id);
-        
+
         return this.prisma.user.update({
             data:{ 
                 name, 
@@ -50,10 +52,13 @@ export class UserSevice {
     }
     async delete(id: number) {
         await this.exists(id);
+
         return this.prisma.user.delete({ where: {id} })
     }
     async exists(id: number) {
-        if (!(await this.readOne(id))) { // se não retornar nada crie uma exceção
+        if (!(await this.prisma.user.count({ // conte quantos registros há com esse id (1:true, 0:false)
+            where:{id}
+        }))) { // se não retornar nada crie uma exceção
             throw new NotFoundException(`O usuário ${id} não existe.`)
         }
     }


### PR DESCRIPTION
A new file  `user-id-check.middleware.ts` was added to the api, for verify the id of requests. It has been configured in `user.module.ts`, to check all requests that use the "user **id**". 

The function exists, in `user.service.ts`, has been improved, because it now counts id records, which can only return 0 or 1 (true or false). This optimizes the process, avoiding unnecessary checks, in addition to avoiding a loop error, because previously the 'readOne' function was called inside this function, making it impossible to do this check inside it as well.